### PR TITLE
Deactivate Mass Assignment Templates

### DIFF
--- a/Mass-Assignment/MassAssignmentBoolean.yaml
+++ b/Mass-Assignment/MassAssignmentBoolean.yaml
@@ -38,6 +38,7 @@ info:
   cve:
     - CVE-2023-32079
     - CVE-2023-42768
+inactive: true
 wordLists:
   booleanValues:
     - true

--- a/Mass-Assignment/MassAssignmentDynamicWordListBoolean.yaml
+++ b/Mass-Assignment/MassAssignmentDynamicWordListBoolean.yaml
@@ -37,6 +37,7 @@ info:
   cve:
     - CVE-2023-32079
     - CVE-2023-42768
+inactive: true
 wordLists:
   ${extraKeys}:
     for_all:

--- a/Mass-Assignment/MassAssignmentDynamicWordListNumber.yaml
+++ b/Mass-Assignment/MassAssignmentDynamicWordListNumber.yaml
@@ -37,7 +37,7 @@ info:
   cve:
     - CVE-2023-32079
     - CVE-2023-42768
-
+inactive: true
 wordLists:
   ${extraKeys}:
     for_all:

--- a/Mass-Assignment/MassAssignmentDynamicWordListString.yaml
+++ b/Mass-Assignment/MassAssignmentDynamicWordListString.yaml
@@ -37,7 +37,7 @@ info:
   cve:
     - CVE-2023-32079
     - CVE-2023-42768
-
+inactive: true
 wordLists:
   ${extraKeys}:
     for_all:


### PR DESCRIPTION
Setting inactive: true for 4 Mass assignment templates to reduce false positives, till the time a new feature is released to handle key:value pairs entered in attempt request getting reflected in the response (with exact same value entered)