### PR TITLE
Fix regex filters

### DIFF
--- a/Threat-Protection/LocalFileInclusion.yml
+++ b/Threat-Protection/LocalFileInclusion.yml
@@ -2,14 +2,14 @@ id: LocalFileInclusionLFIRFI
 filter:
   or:
     - request_payload:
-      regex:
-        - (?i)(?:^|[^a-zA-Z0-9])(?:(?:\\.\\.(?:/|\\\\|%2F|%5C))+\\.?|(?:/|\\\\|%2F|%5C)(?:etc/passwd|proc/self/environ|windows/system\\.ini)|php://(?:filter|input)|(?:/|\\\\|%2F|%5C)\\w+\\.(?:php|conf|ini|log)(?:%00|\0)?)(?:$|[^a-zA-Z0-9])
+        regex:
+          - (?i)(?:^|[^a-zA-Z0-9])(?:(?:\.\.(?:/|\\|%2F|%5C))+\.?|(?:/|\\|%2F|%5C)(?:etc/passwd|proc/self/environ|windows/system\.ini)|php://(?:filter|input)|(?:/|\\|%2F|%5C)\w+\.(?:php|conf|ini|log)(?:%00)?)(?:$|[^a-zA-Z0-9])
     - request_headers:
-      regex:
-        - (?i)(?:^|[^a-zA-Z0-9])(?:(?:\\.\\.(?:/|\\\\|%2F|%5C))+\\.?|(?:/|\\\\|%2F|%5C)(?:etc/passwd|proc/self/environ|windows/system\\.ini)|php://(?:filter|input)|(?:/|\\\\|%2F|%5C)\\w+\\.(?:php|conf|ini|log)(?:%00|\0)?)(?:$|[^a-zA-Z0-9])
+        regex:
+          - (?i)(?:^|[^a-zA-Z0-9])(?:(?:\.\.(?:/|\\|%2F|%5C))+\.?|(?:/|\\|%2F|%5C)(?:etc/passwd|proc/self/environ|windows/system\.ini)|php://(?:filter|input)|(?:/|\\|%2F|%5C)\w+\.(?:php|conf|ini|log)(?:%00)?)(?:$|[^a-zA-Z0-9])
     - url:
-      regex:
-        - (?i)(?:^|[^a-zA-Z0-9])(?:(?:\\.\\.(?:/|\\\\|%2F|%5C))+\\.?|(?:/|\\\\|%2F|%5C)(?:etc/passwd|proc/self/environ|windows/system\\.ini)|php://(?:filter|input)|(?:/|\\\\|%2F|%5C)\\w+\\.(?:php|conf|ini|log)(?:%00|\0)?)(?:$|[^a-zA-Z0-9])
+        regex:
+          - (?i)(?:^|[^a-zA-Z0-9])(?:(?:\.\.(?:/|\\|%2F|%5C))+\.?|(?:/|\\|%2F|%5C)(?:etc/passwd|proc/self/environ|windows/system\.ini)|php://(?:filter|input)|(?:/|\\|%2F|%5C)\w+\.(?:php|conf|ini|log)(?:%00)?)(?:$|[^a-zA-Z0-9])
 
 info:
   name: "LocalFileInclusionRFI"

--- a/Threat-Protection/SQLInjection.yml
+++ b/Threat-Protection/SQLInjection.yml
@@ -3,14 +3,15 @@ filter:
   or: 
     - request_headers:
         regex:
-          - (?i)(?:\\b(?:select|insert|drop)\\s+(?:from|into|all|\\*|\\b\\d+\\b|['\";])|\\b1=1\\b|or\\s+\\S+\\s*=\\s*\\S+|/\\*)(?:\\s|$)
+          - (?i)(?:\bdrop\s+table\s+\w+\s*;|\b(?:['"]?1=1['"]?|or\s+\S+\s*=\s*\S+))
           
     - query_param:
         regex:
-          - (?i)(?:\\b(?:select|insert|drop)\\s+(?:from|into|all|\\*|\\b\\d+\\b|['\";])|\\b1=1\\b|or\\s+\\S+\\s*=\\s*\\S+|/\\*)(?:\\s|$)
+          - (?i)(?:\bdrop\s+table\s+\w+\s*;|\b(?:['"]?1=1['"]?|or\s+\S+\s*=\s*\S+))
+
     - request_payload:
         regex:
-          - (?i)(?:\\b(?:select|insert|drop)\\s+(?:from|into|all|\\*|\\b\\d+\\b|['\";])|\\b1=1\\b|or\\s+\\S+\\s*=\\s*\\S+|/\\*)(?:\\s|$)
+          - (?i)(?:\bdrop\s+table\s+\w+\s*;|\b(?:['"]?1=1['"]?|or\s+\S+\s*=\s*\S+))
 
 info:
   name: "SQLInjection"

--- a/Threat-Protection/SSRF.yml
+++ b/Threat-Protection/SSRF.yml
@@ -3,13 +3,13 @@ filter:
   or: 
     - request_payload:
         regex:
-          - (?i)\\b(?:http://)?(?:localhost|127\\.0\\.0\\.1|169\\.254\\.169\\.254|attacker\\.com|webhook\\.site)(?:/admin)?\\b
+          - (?i)\bhttp(s)?://(?:localhost|127\.0\.0\.1|169\.254\.169\.254|attacker\.com|webhook\.site)(?:/admin)?\b
     - query_param:
         regex:
-          - (?i)\\b(?:http://)?(?:localhost|127\\.0\\.0\\.1|169\\.254\\.169\\.254|attacker\\.com|webhook\\.site)(?:/admin)?\\b
+          - (?i)\bhttp(s)?://(?:localhost|127\.0\.0\.1|169\.254\.169\.254|attacker\.com|webhook\.site)(?:/admin)?\b
     - request_headers:
         regex:
-          - (?i)\\b(?:http://)?(?:localhost|127\\.0\\.0\\.1|169\\.254\\.169\\.254|attacker\\.com|webhook\\.site)(?:/admin)?\\b
+          - (?i)\bhttp(s)?://(?:localhost|127\.0\.0\.1|169\.254\.169\.254|attacker\.com|webhook\.site)(?:/admin)?\b
 
 info:
   name: "SSRF"


### PR DESCRIPTION
Java requires `\\` to escape the `\`. Although this escaping is only required when writing string directly in code, if reading from .yaml file no escaping is required.